### PR TITLE
export only FlounderReact as a class instead of an object of various …

### DIFF
--- a/src/flounder.react.jsx
+++ b/src/flounder.react.jsx
@@ -279,5 +279,5 @@ Object.defineProperty( FlounderReact.prototype, 'version', {
     }
 } );
 console.log( version );
-export default { React, Component, ReactDOM, FlounderReact, Flounder };
 
+export default  FlounderReact;


### PR DESCRIPTION
We only need to export FlounderReact here, so let's do that?
